### PR TITLE
Lock ranges for FPC 3.2.2 update

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  ENTRYCLIENT_VERSION: "4.6"
+  ENTRYCLIENT_VERSION: "1.0"
 
 jobs:
   setup:
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate Maven settings.xml
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v22
         with:
           output_file: "/etc/maven/settings.xml"
           servers:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  ENTRYCLIENT_VERSION: "4.6"
+  ENTRYCLIENT_VERSION: "1.0"
 
 jobs:
   setup:
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate Maven settings.xml
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v22
         with:
           output_file: "/etc/maven/settings.xml"
           servers:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>dk.epidata.entryclient</groupId>
     <artifactId>epidata-entryclient</artifactId>
-    <version>4.6</version>
+    <version>1.0</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>dk.epidata.lazarus</groupId>
             <artifactId>lazarus</artifactId>
-            <version>[2.0.10,2.0.11)</version>
+            <version>2.0.10</version>
             <type>pom</type>
         </dependency>
         <dependency>
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>dk.epidata.core</groupId>
             <artifactId>epidata-core</artifactId>
-            <version>[4.6,4.7)</version>
+            <version>[1.0,1.1)</version>
             <type>pom</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* Lock lazarus to 2.0.10
* Change core range to [1.0,1.1)
* Change own version to 1.0 to support new maven version ranges