### PR TITLE
Fix message in failed comparison

### DIFF
--- a/src/dataform/dataform_frame.pas
+++ b/src/dataform/dataform_frame.pas
@@ -2672,7 +2672,7 @@ begin
     begin
       Err := Format(
         'Comparison failed:' + LineEnding +
-        '%s: %s  %s  %s: %s',
+        '%s: %s is not %s  %s: %s',
         [Field.Name, CE.Text, ComparisonTypeToString(Field.Comparison.CompareType),
          Field.Name, NewEdit.Text]);
       FieldValidateError(CE, Err);

--- a/src/dataform/dataform_frame.pas
+++ b/src/dataform/dataform_frame.pas
@@ -2674,7 +2674,7 @@ begin
         'Comparison failed:' + LineEnding +
         '%s: %s is not %s  %s: %s',
         [Field.Name, CE.Text, ComparisonTypeToString(Field.Comparison.CompareType),
-         Field.Name, NewEdit.Text]);
+         Field.Comparison.CompareField.Name, NewEdit.Text]);
       FieldValidateError(CE, Err);
       Exit(fxtError);
     end;


### PR DESCRIPTION
For proper sense, "is not" added before the comparison operator.
Close issue.